### PR TITLE
Add UNIX user name

### DIFF
--- a/src/auth/AuthInit.tsx
+++ b/src/auth/AuthInit.tsx
@@ -24,6 +24,7 @@ const formatInitialData = pick([
   'job_title',
   'description',
   'phone_number',
+  'unix_username',
 ]);
 
 export const AuthInit: FunctionComponent = () => {

--- a/src/resource/actions/base.spec.ts
+++ b/src/resource/actions/base.spec.ts
@@ -15,6 +15,7 @@ const user = {
   is_staff: true,
   url: 'Valid URL',
   uuid: 'Valid UUID',
+  unix_username: 'Valid UNIX username',
 };
 const ctx = { resource, user };
 

--- a/src/user/constants.ts
+++ b/src/user/constants.ts
@@ -3,6 +3,7 @@ import { UserDetails } from '@waldur/workspace/types';
 export const USER_PROFILE_COMPLETION_FIELDS: Array<keyof UserDetails> = [
   'first_name',
   'last_name',
+  'unix_username',
   'email',
   'job_title',
   'organization',

--- a/src/user/support/UserEditForm.spec.tsx
+++ b/src/user/support/UserEditForm.spec.tsx
@@ -27,6 +27,7 @@ describe('UserEditForm', () => {
     expect(wrapper.find({ label: 'Job position' }).length).toBe(1);
     expect(wrapper.find({ label: 'Description' }).length).toBe(1);
     expect(wrapper.find({ label: 'Phone number' }).length).toBe(1);
+    expect(wrapper.find({ label: 'UNIX user name' }).length).toBe(1);
     expect(wrapper.find(TermsOfService).length).toBe(1);
   });
 

--- a/src/user/support/UserEditForm.tsx
+++ b/src/user/support/UserEditForm.tsx
@@ -27,6 +27,7 @@ interface UserEditFormData {
   job_position: string;
   description: string;
   phone_number: string;
+  unix_username: string;
 }
 interface OwnProps {
   updateUser(data: UserEditFormData): Promise<void>;
@@ -37,6 +38,20 @@ interface OwnProps {
   nativeNameIsVisible: boolean;
   user: UserDetails;
   fieldIsProtected(field: string): boolean;
+}
+
+function validateUnixUsername(value) {
+  if (!value) {
+    return undefined;
+  } else if (value.length > 20) {
+    return 'Must be 20 characters or less';
+  } else if (value.length < 5) {
+    return 'Must be 5 characters or more';
+  } else if (!value.match(/^[a-z][a-z0-9]+$/)) {
+    return 'Must only contain numbers and lowercase-letters and start with a letter.';
+  } else {
+    return undefined;
+  }
 }
 
 export const PureUserEditForm: FunctionComponent<
@@ -74,6 +89,24 @@ export const PureUserEditForm: FunctionComponent<
           label={translate('Native name')}
           value={props.user.native_name}
           protected
+          disabled
+        />
+      )}
+      {!props.user.unix_username && (
+        <StringField
+          label={translate('UNIX user name')}
+          name="unix_username"
+          required={props.isRequired('unix_username')}
+          description={translate(
+            'A short, unique name for you. It will be used to form your local username on any systems. Should only contain lower-case letters and digits and must start with a letter. Must be between 5-20 characters long.',
+          )}
+          validate={[validateUnixUsername]}
+        />
+      )}
+      {props.user.unix_username && (
+        <StaticField
+          label={translate('UNIX user name')}
+          value={props.user.unix_username}
           disabled
         />
       )}

--- a/src/user/support/api.ts
+++ b/src/user/support/api.ts
@@ -14,6 +14,7 @@ export const updateUser = (user) => {
     phone_number: user.phone_number,
     agree_with_policy: user.agree_with_policy,
     token_lifetime: user.token_lifetime.value,
+    unix_username: user.unix_username,
   };
   if (!user.image) {
     // If user tries to remove image

--- a/src/workspace/types.ts
+++ b/src/workspace/types.ts
@@ -25,6 +25,7 @@ export interface User {
   email?: string;
   job_title?: string;
   organization?: string;
+  unix_username: string;
 }
 
 export interface UserDetails extends User {


### PR DESCRIPTION
This field can be set at initial user data creation or in their settings later on. It is not required, but if it is set then it cannot be changed.